### PR TITLE
v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,18 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [0.1.0] - 2024-01-06
+
 ### Added
 
-- Add Tabs element
-- Emit `twc-switch:change` cancelable event before toggling the switch
+- Add Tabs element ([#14](https://github.com/abeidahmed/tailwindcss-elements/pull/14))
+- Emit `twc-switch:change` cancelable event before toggling the switch ([#12](https://github.com/abeidahmed/tailwindcss-elements/pull/12))
 
 ### Changed
 
-- Change `uniqueId` prefix to `twc`
+- Change `uniqueId` prefix to `twc` ([#11](https://github.com/abeidahmed/tailwindcss-elements/pull/11))
 
 ### Fixed
 
-- Hide dialog element before Turbo caches the page
+- Hide dialog element before Turbo caches the page ([#13](https://github.com/abeidahmed/tailwindcss-elements/pull/13))
 
 ## [0.0.1] - 2024-01-04
 
@@ -28,5 +30,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add Popover element ([#3](https://github.com/abeidahmed/tailwindcss-elements/pull/3))
 - Add Switch element ([#2](https://github.com/abeidahmed/tailwindcss-elements/pull/2))
 
-[unreleased]: https://github.com/abeidahmed/tailwindcss-elements/compare/v0.0.1...HEAD
+[unreleased]: https://github.com/abeidahmed/tailwindcss-elements/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/abeidahmed/tailwindcss-elements/compare/v0.0.1...v0.1.0
 [0.0.1]: https://github.com/abeidahmed/tailwindcss-elements/releases/tag/v0.0.1

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tailwindcss-elements",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "A set of accessible custom elements that pairs beautifully with Tailwind CSS.",
   "author": "abeidahmed",
   "license": "MIT",


### PR DESCRIPTION
## [0.1.0] - 2024-01-06

### Added

- Add Tabs element ([#14](https://github.com/abeidahmed/tailwindcss-elements/pull/14))
- Emit `twc-switch:change` cancelable event before toggling the switch ([#12](https://github.com/abeidahmed/tailwindcss-elements/pull/12))

### Changed

- Change `uniqueId` prefix to `twc` ([#11](https://github.com/abeidahmed/tailwindcss-elements/pull/11))

### Fixed

- Hide dialog element before Turbo caches the page ([#13](https://github.com/abeidahmed/tailwindcss-elements/pull/13))
