### PR TITLE
v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [0.2.0] - 2024-01-14
+
 ### Added
 
-- Add Floating panel element
+- Add Floating panel element ([#24](https://github.com/abeidahmed/tailwindcss-elements/pull/24))
 
 ### Fixed
 
-- Make dropdown element initially visible if `open` attribute is set
-- Export tabs element from `package.json` file
+- Make dropdown element initially visible if `open` attribute is set ([#25](https://github.com/abeidahmed/tailwindcss-elements/pull/25))
+- Export tabs element from `package.json` file ([#21](https://github.com/abeidahmed/tailwindcss-elements/pull/21))
 
 ## [0.1.0] - 2024-01-06
 
@@ -39,6 +41,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add Popover element ([#3](https://github.com/abeidahmed/tailwindcss-elements/pull/3))
 - Add Switch element ([#2](https://github.com/abeidahmed/tailwindcss-elements/pull/2))
 
-[unreleased]: https://github.com/abeidahmed/tailwindcss-elements/compare/v0.1.0...HEAD
+[unreleased]: https://github.com/abeidahmed/tailwindcss-elements/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/abeidahmed/tailwindcss-elements/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/abeidahmed/tailwindcss-elements/compare/v0.0.1...v0.1.0
 [0.0.1]: https://github.com/abeidahmed/tailwindcss-elements/releases/tag/v0.0.1

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tailwindcss-elements",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "A set of accessible custom elements that pairs beautifully with Tailwind CSS.",
   "author": "abeidahmed",
   "license": "MIT",


### PR DESCRIPTION
## [0.2.0] - 2024-01-14

### Added

- Add Floating panel element ([#24](https://github.com/abeidahmed/tailwindcss-elements/pull/24))

### Fixed

- Make dropdown element initially visible if `open` attribute is set ([#25](https://github.com/abeidahmed/tailwindcss-elements/pull/25))
- Export tabs element from `package.json` file ([#21](https://github.com/abeidahmed/tailwindcss-elements/pull/21))
