### PR TITLE
feat(tooltip): add new tooltip element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Add Tooltip element
 - Support arrow in Floating panel element
 - Allow trigger id to be set in the Floating panel element
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ import 'tailwindcss-elements/elements/dropdown';
 - [Popover](./packages/core/src/elements/popover/README.md)
 - [Switch](./packages/core/src/elements/switch/README.md)
 - [Tabs](./packages/core/src/elements/tabs/README.md)
+- [Tooltip](./packages/core/src/elements/tooltip/README.md)
 
 ## Styling
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -45,6 +45,10 @@
     "./elements/tabs": {
       "types": "./dist/elements/tabs/index.d.ts",
       "default": "./dist/elements/tabs/index.js"
+    },
+    "./elements/tooltip": {
+      "types": "./dist/elements/tooltip/index.d.ts",
+      "default": "./dist/elements/tooltip/index.js"
     }
   },
   "files": [
@@ -65,6 +69,7 @@
   "dependencies": {
     "@ambiki/impulse": "^0.2.0",
     "@floating-ui/dom": "^1.6.3",
+    "@oddbird/popover-polyfill": "^0.4.0",
     "composed-offset-position": "^0.0.4",
     "tabbable": "^6.2.0"
   }

--- a/packages/core/src/elements/tooltip/README.md
+++ b/packages/core/src/elements/tooltip/README.md
@@ -1,0 +1,45 @@
+# Tooltip
+
+A tooltip is a popup that displays information related to an element when the element receives keyboard focus or the
+mouse hovers over it.
+
+**Note:** The tooltip element uses the [`popover`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/popover)
+attribute and comes with a [polyfill](https://github.com/oddbird/popover-polyfill).
+
+## Imports
+
+```js
+import 'tailwindcss-elements/elements/tooltip';
+```
+
+## Usage
+
+```html
+<twc-tooltip>
+  <button type="button" data-target="twc-tooltip.trigger">Hover me</button>
+  <div data-target="twc-tooltip.panel" class="m-0">Hello, Tooltip!</div>
+</twc-tooltip>
+```
+
+## Examples
+
+### Positioning the panel
+
+By default, the positioning logic is not taken care of when you use the `twc-tooltip` element. But, you can do so by
+wrapping the trigger and panel with the [`twc-floating-panel`](../floating_panel/README.md) element.
+
+```html
+<twc-tooltip>
+  <twc-floating-panel>
+    <button type="button" data-target="twc-tooltip.trigger twc-floating-panel.trigger">Hover me</button>
+    <div data-target="twc-tooltip.panel twc-floating-panel.panel" class="m-0">Hello, Tooltip!</div>
+  </twc-floating-panel>
+</twc-tooltip>
+```
+
+## Events
+
+| Name                 | Bubbles   | Description                                                       |
+| ------               | --------- | ------------                                                      |
+| `twc-tooltip:shown`  | `true`    | This event fires when the tooltip is shown via user interaction.  |
+| `twc-tooltip:hidden` | `true`    | This event fires when the tooltip is hidden via user interaction. |

--- a/packages/core/src/elements/tooltip/index.test.ts
+++ b/packages/core/src/elements/tooltip/index.test.ts
@@ -1,0 +1,146 @@
+import { expect, fixture, html } from '@open-wc/testing';
+import { sendMouse } from '@web/test-runner-commands';
+import Sinon from 'sinon';
+import FloatingPanelElement from '../floating_panel';
+import TooltipElement from './index';
+
+function assertTooltipShown(button: HTMLButtonElement, panel: HTMLElement) {
+  expect(button).to.have.attribute('data-headlessui-state', 'open');
+  expect(panel).to.have.attribute('data-headlessui-state', 'open');
+}
+
+function assertTooltipHidden(button: HTMLButtonElement, panel: HTMLElement) {
+  expect(button).to.have.attribute('data-headlessui-state', '');
+  expect(panel).to.have.attribute('data-headlessui-state', '');
+}
+
+describe('Tooltip', () => {
+  it('sets the attributes', async () => {
+    const el = await fixture<TooltipElement>(html`
+      <twc-tooltip>
+        <button type="button" data-target="twc-tooltip.trigger">Hover</button>
+        <div data-target="twc-tooltip.panel">Contents!</div>
+      </twc-tooltip>
+    `);
+
+    const button = el.querySelector('button')!;
+    const panel = el.querySelector('div')!;
+
+    assertTooltipHidden(button, panel);
+    expect(panel).to.have.attribute('popover', 'auto');
+    expect(panel).to.have.attribute('role', 'tooltip');
+    expect(panel).to.have.attribute('id');
+    expect(button).to.have.attribute('aria-describedby', panel.id);
+  });
+
+  it('shows the tooltip on keyboard focus', async () => {
+    const el = await fixture<TooltipElement>(html`
+      <twc-tooltip>
+        <button type="button" data-target="twc-tooltip.trigger">Hover</button>
+        <div data-target="twc-tooltip.panel">Contents!</div>
+      </twc-tooltip>
+    `);
+
+    const shownHandler = Sinon.spy();
+    el.addEventListener(`${el.identifier}:shown`, shownHandler);
+
+    const button = el.querySelector('button')!;
+    const panel = el.querySelector('div')!;
+
+    button.focus();
+    assertTooltipShown(button, panel);
+    expect(shownHandler.calledOnce).to.be.true;
+  });
+
+  it('toggles the visibility of the tooltip on mouse hover', async () => {
+    const el = await fixture<TooltipElement>(html`
+      <twc-tooltip>
+        <button type="button" data-target="twc-tooltip.trigger">Hover</button>
+        <div data-target="twc-tooltip.panel">Contents!</div>
+      </twc-tooltip>
+    `);
+
+    const shownHandler = Sinon.spy();
+    el.addEventListener(`${el.identifier}:shown`, shownHandler);
+
+    const hiddenHandler = Sinon.spy();
+    el.addEventListener(`${el.identifier}:hidden`, hiddenHandler);
+
+    const button = el.querySelector('button')!;
+    const panel = el.querySelector('div')!;
+    const { x, y } = button.getBoundingClientRect();
+
+    await sendMouse({ type: 'move', position: [x, y] });
+    assertTooltipShown(button, panel);
+    expect(shownHandler.calledOnce).to.be.true;
+
+    await sendMouse({ type: 'move', position: [0, 0] });
+    assertTooltipHidden(button, panel);
+    expect(hiddenHandler.calledOnce).to.be.true;
+  });
+
+  it('hides the tooltip when trigger is clicked', async () => {
+    const el = await fixture<TooltipElement>(html`
+      <twc-tooltip>
+        <button type="button" data-target="twc-tooltip.trigger">Hover</button>
+        <div data-target="twc-tooltip.panel">Contents!</div>
+      </twc-tooltip>
+    `);
+
+    const hiddenHandler = Sinon.spy();
+    el.addEventListener(`${el.identifier}:hidden`, hiddenHandler);
+
+    const button = el.querySelector('button')!;
+    const panel = el.querySelector('div')!;
+    const { x, y } = button.getBoundingClientRect();
+
+    await sendMouse({ type: 'move', position: [x, y] });
+    assertTooltipShown(button, panel);
+
+    await sendMouse({ type: 'click', position: [x, y] });
+    assertTooltipHidden(button, panel);
+    expect(hiddenHandler.calledOnce).to.be.true;
+  });
+
+  it('hides the tooltip when trigger is blurred', async () => {
+    const el = await fixture<TooltipElement>(html`
+      <twc-tooltip>
+        <button type="button" data-target="twc-tooltip.trigger">Hover</button>
+        <div data-target="twc-tooltip.panel">Contents!</div>
+      </twc-tooltip>
+    `);
+
+    const hiddenHandler = Sinon.spy();
+    el.addEventListener(`${el.identifier}:hidden`, hiddenHandler);
+
+    const button = el.querySelector('button')!;
+    const panel = el.querySelector('div')!;
+
+    button.focus();
+    assertTooltipShown(button, panel);
+
+    button.blur();
+    assertTooltipHidden(button, panel);
+    expect(hiddenHandler.calledOnce).to.be.true;
+  });
+
+  it('starts and stops the positioning logic', async () => {
+    const el = await fixture<TooltipElement>(html`
+      <twc-tooltip>
+        <twc-floating-panel>
+          <button type="button" data-target="twc-tooltip.trigger twc-floating-panel.trigger">Hover</button>
+          <div data-target="twc-tooltip.panel twc-floating-panel.panel">Contents!</div>
+        </twc-floating-panel>
+      </twc-tooltip>
+    `);
+
+    const floatingPanel = el.querySelector('twc-floating-panel')! as FloatingPanelElement;
+    const button = el.querySelector('button')!;
+
+    button.focus();
+    expect(floatingPanel).to.have.attribute('active');
+
+    button.blur();
+    expect(floatingPanel).not.to.have.attribute('active');
+  });
+});

--- a/packages/core/src/elements/tooltip/index.ts
+++ b/packages/core/src/elements/tooltip/index.ts
@@ -1,0 +1,138 @@
+import { ImpulseElement, registerElement, target } from '@ambiki/impulse';
+import { apply, isSupported } from '@oddbird/popover-polyfill/fn';
+import { setSafeAttribute } from '../../helpers/dom';
+import uniqueId from '../../helpers/unique_id';
+
+@registerElement('twc-tooltip')
+export default class TooltipElement extends ImpulseElement {
+  @target() trigger: HTMLElement;
+  @target() panel: HTMLElement;
+
+  private isMousedown = false;
+  private isMousemove = false;
+  private triggerController = new AbortController();
+
+  connected() {
+    if (!isSupported()) {
+      apply();
+    }
+
+    this.trigger.setAttribute('aria-describedby', this.panel.id);
+  }
+
+  disconnected() {
+    this.isMousedown = false;
+    this.isMousemove = false;
+    this.hide();
+  }
+
+  triggerConnected(trigger: HTMLElement) {
+    const { signal } = this.triggerController;
+    trigger.addEventListener('mousedown', this.handleMousedown.bind(this), { signal });
+    trigger.addEventListener('focus', this.handleFocus.bind(this), { signal });
+    trigger.addEventListener('blur', this.handleBlur.bind(this), { signal });
+    trigger.addEventListener('mousemove', this.handleMousemove.bind(this), { signal });
+    trigger.addEventListener('mouseleave', this.handleMouseleave.bind(this), { signal });
+
+    trigger.setAttribute('data-headlessui-state', '');
+  }
+
+  triggerDisconnected() {
+    this.triggerController.abort();
+  }
+
+  panelConnected(panel: HTMLElement) {
+    panel.setAttribute('popover', 'auto');
+    panel.setAttribute('role', 'tooltip');
+    setSafeAttribute(panel, 'id', uniqueId());
+    panel.setAttribute('data-headlessui-state', '');
+  }
+
+  private handleMousedown() {
+    this.isMousedown = true;
+    document.addEventListener(
+      'mouseup',
+      () => {
+        this.isMousedown = false;
+      },
+      { once: true }
+    );
+    this.hide();
+    this.emit('hidden');
+  }
+
+  private handleFocus() {
+    if (!this.isMousedown) {
+      this.show();
+      this.emit('shown');
+    }
+  }
+
+  private handleBlur() {
+    this.hide();
+    this.emit('hidden');
+  }
+
+  private handleMousemove() {
+    if (!this.isMousemove) {
+      this.show();
+      this.emit('shown');
+      this.isMousemove = true;
+    }
+  }
+
+  private handleMouseleave() {
+    this.hide();
+    this.emit('hidden');
+    this.isMousemove = false;
+  }
+
+  /**
+   * Shows the tooltip.
+   */
+  show() {
+    if (!this.open) {
+      if (this.floatingPanel) {
+        this.floatingPanel.active = true;
+      }
+      this.panel.showPopover();
+      this.panel.setAttribute('data-headlessui-state', 'open');
+      this.trigger.setAttribute('data-headlessui-state', 'open');
+    }
+  }
+
+  /**
+   * Hides the tooltip.
+   */
+  hide() {
+    // Called on the `disconnected` lifecycle callback and we need to make sure that these elements are defined.
+    if (this.panel && this.open) {
+      this.panel.hidePopover();
+      this.panel.setAttribute('data-headlessui-state', '');
+      this.trigger?.setAttribute('data-headlessui-state', '');
+      if (this.floatingPanel) {
+        this.floatingPanel.active = false;
+      }
+    }
+  }
+
+  /**
+   * Whether the tooltip is open or not.
+   */
+  get open() {
+    return this.panel.matches(':popover-open');
+  }
+
+  get floatingPanel() {
+    return this.querySelector('twc-floating-panel');
+  }
+}
+
+declare global {
+  interface Window {
+    TooltipElement: typeof TooltipElement;
+  }
+  interface HTMLElementTagNameMap {
+    'twc-tooltip': TooltipElement;
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,3 +4,4 @@ import './elements/floating_panel';
 import './elements/popover';
 import './elements/switch';
 import './elements/tabs';
+import './elements/tooltip';

--- a/packages/playground/index.html
+++ b/packages/playground/index.html
@@ -147,6 +147,25 @@
         </twc-floating-panel>
       </div>
     </div>
+
+    <div class="mt-20">
+      <h2>Tooltip element</h2>
+      <twc-tooltip>
+        <twc-floating-panel placement="top" offset-options="8">
+          <button type="button" data-target="twc-tooltip.trigger twc-floating-panel.trigger">Hover me</button>
+          <div
+            data-target="twc-tooltip.panel twc-floating-panel.panel"
+            class="m-0 group overflow-visible bg-gray-900 rounded text-white py-1 px-2"
+          >
+            <div
+              class="absolute h-0 w-0 border-x-[10px] border-x-transparent border-t-[10px] border-t-gray-900 group-data-[current-placement^='top']:-bottom-2 group-data-[current-placement^='bottom']:-top-2 group-data-[current-placement^='right']:-left-2 group-data-[current-placement^='left']:-right-2"
+              data-target="twc-floating-panel.arrow"
+            ></div>
+            Hello, Tooltip!
+          </div>
+        </twc-floating-panel>
+      </twc-tooltip>
+    </div>
     <script type="module" src="/src/index.ts"></script>
   </body>
 </html>

--- a/yarn.lock
+++ b/yarn.lock
@@ -298,6 +298,11 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@oddbird/popover-polyfill@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@oddbird/popover-polyfill/-/popover-polyfill-0.4.0.tgz#abba79014e670b6d95451512b29afca99eab571a"
+  integrity sha512-jrqoTI8lk5UziDsDPJ2Y+nmXYCcRhmr6uMARr3v/W6AMxRgsnRLWJyWKYr6FjaGMgbyxXG+OkCUPQY4Xl3toGg==
+
 "@open-wc/dedupe-mixin@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@open-wc/dedupe-mixin/-/dedupe-mixin-1.4.0.tgz#b3c58f8699b197bb5e923d624c720e67c9f324d6"


### PR DESCRIPTION
The tooltip element uses the `popover` attribute and comes with a polyfill for browsers that do not support this feature, yet.

```html
<twc-tooltip>
  <button type="button" data-target="twc-tooltip.trigger">Hover me</button>
  <div data-target="twc-tooltip.panel">Hello, Tooltip!</div>
</twc-tooltip>
```