### PR TITLE
v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [0.4.0] - 2024-05-25
+
 ### Changed
 
-- Use `popover` attribute in the popover element
+- Use `popover` attribute in the popover element ([#40](https://github.com/abeidahmed/tailwindcss-elements/pull/40))
 
 ### Fixed
 
-- Do not click menuitem again
+- Do not click menuitem again ([#39](https://github.com/abeidahmed/tailwindcss-elements/pull/39))
 
 ## [0.3.1] - 2024-04-26
 
@@ -68,7 +70,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add Popover element ([#3](https://github.com/abeidahmed/tailwindcss-elements/pull/3))
 - Add Switch element ([#2](https://github.com/abeidahmed/tailwindcss-elements/pull/2))
 
-[unreleased]: https://github.com/abeidahmed/tailwindcss-elements/compare/v0.3.1...HEAD
+[unreleased]: https://github.com/abeidahmed/tailwindcss-elements/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/abeidahmed/tailwindcss-elements/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/abeidahmed/tailwindcss-elements/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/abeidahmed/tailwindcss-elements/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/abeidahmed/tailwindcss-elements/compare/v0.1.0...v0.2.0

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tailwindcss-elements",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "A set of accessible custom elements that pairs beautifully with Tailwind CSS.",
   "author": "abeidahmed",
   "license": "MIT",


### PR DESCRIPTION
### Changed

- Use `popover` attribute in the popover element ([#40](https://github.com/abeidahmed/tailwindcss-elements/pull/40))

### Fixed

- Do not click menuitem again ([#39](https://github.com/abeidahmed/tailwindcss-elements/pull/39))
